### PR TITLE
added required export/import for unix socket connection

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.bluetooth.bluez/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.bluetooth.bluez/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.smarthome.io.transport.bluetooth.bluez
-Import-Package: javax.net,
+Import-Package: cx.ath.matthew.unix;resolution:=optional,
+ javax.net,
  javax.net.ssl,
  org.apache.commons.lang,
  org.eclipse.smarthome.core.events,
@@ -16,9 +17,9 @@ Import-Package: javax.net,
  org.freedesktop,
  org.freedesktop.dbus,
  org.freedesktop.dbus.exceptions,
- org.osgi.framework;version="1.8.0",
+ org.osgi.framework,
  org.osgi.service.cm,
- org.osgi.service.component;version="1.2.2",
+ org.osgi.service.component,
  org.slf4j
 Bundle-ClassPath: .
 Service-Component: OSGI-INF/*.xml

--- a/bundles/io/org.eclipse.smarthome.io.transport.dbus/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.dbus/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Export-Package:  org.freedesktop,
  org.freedesktop.dbus,
  org.freedesktop.dbus.exceptions,
  cx.ath.matthew.debug,
- cx.ath.matthew.utils
+ cx.ath.matthew.utils,
+ cx.ath.matthew.unix
 Import-Package: 
  org.apache.commons.lang,
  org.slf4j


### PR DESCRIPTION
I needed this in order to run it on OH2/Karaf with unix socket connection.

Signed-off-by: Kai Kreuzer kai@openhab.org
