### PR TITLE
Tradfri: Use HSBType toXY convert method

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriColorTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriColorTest.java
@@ -27,144 +27,120 @@ public class TradfriColorTest {
 
     @Test
     public void testFromCieKnownGood1() {
-        TradfriColor color = TradfriColor.fromCie(29577, 12294, 354);
-        assertNotNull(color);
-        assertEquals(254, (int) color.rgbR);
-        assertEquals(2, (int) color.rgbG);
-        assertEquals(158, (int) color.rgbB);
+        TradfriColor color = new TradfriColor(29577, 12294, 354);
         assertEquals(29577, (int) color.xyX);
         assertEquals(12294, (int) color.xyY);
         assertEquals(254, (int) color.brightness);
-        assertNotNull(color.hsbType);
-        assertEquals(323, color.hsbType.getHue().intValue());
-        assertEquals(99, color.hsbType.getSaturation().intValue());
-        assertEquals(100, color.hsbType.getBrightness().intValue());
+        HSBType hsbType = color.getHSB();
+        assertNotNull(hsbType);
+        assertEquals(321, hsbType.getHue().intValue());
+        assertEquals(100, hsbType.getSaturation().intValue());
+        assertEquals(100, hsbType.getBrightness().intValue());
     }
 
     @Test
     public void testFromCieKnownGood2() {
-        TradfriColor color = TradfriColor.fromCie(19983, 37417, 84);
-        assertNotNull(color);
-        assertEquals(30, (int) color.rgbR);
-        assertEquals(86, (int) color.rgbG);
-        assertEquals(7, (int) color.rgbB);
+        TradfriColor color = new TradfriColor(19983, 37417, 84);
         assertEquals(19983, (int) color.xyX);
         assertEquals(37417, (int) color.xyY);
         assertEquals(84, (int) color.brightness);
-        assertNotNull(color.hsbType);
-        assertEquals(102, color.hsbType.getHue().intValue());
-        assertEquals(89, color.hsbType.getSaturation().intValue());
-        assertEquals(34, color.hsbType.getBrightness().intValue());
+        HSBType hsbType = color.getHSB();
+        assertNotNull(hsbType);
+        assertEquals(115, hsbType.getHue().intValue());
+        assertEquals(77, hsbType.getSaturation().intValue());
+        assertEquals(34, hsbType.getBrightness().intValue());
     }
 
     @Test
     public void testFromCieKnownGood3() {
-        TradfriColor color = TradfriColor.fromCie(19983, 37417, 1);
-        assertNotNull(color);
-        assertEquals(0, (int) color.rgbR);
-        assertEquals(2, (int) color.rgbG);
-        assertEquals(0, (int) color.rgbB);
+        TradfriColor color = new TradfriColor(19983, 37417, 1);
         assertEquals(19983, (int) color.xyX);
         assertEquals(37417, (int) color.xyY);
         assertEquals(1, (int) color.brightness);
-        assertNotNull(color.hsbType);
-        assertEquals(120, color.hsbType.getHue().intValue());
-        assertEquals(100, color.hsbType.getSaturation().intValue());
-        assertEquals(1, color.hsbType.getBrightness().intValue());
+        HSBType hsbType = color.getHSB();
+        assertNotNull(hsbType);
+        assertEquals(115, hsbType.getHue().intValue());
+        assertEquals(77, hsbType.getSaturation().intValue());
+        assertEquals(1, hsbType.getBrightness().intValue());
     }
 
     @Test
     public void testFromCieKnownGood4() {
-        TradfriColor color = TradfriColor.fromCie(11469, 3277, 181);
-        assertNotNull(color);
-        assertEquals(12, (int) color.rgbR);
-        assertEquals(0, (int) color.rgbG);
-        assertEquals(183, (int) color.rgbB);
-        assertEquals(11469, (int) color.xyX);
-        assertEquals(3277, (int) color.xyY);
+        TradfriColor color = new TradfriColor(11413, 31334, 181);
+        assertEquals(11413, (int) color.xyX);
+        assertEquals(31334, (int) color.xyY);
         assertEquals(181, (int) color.brightness);
-        assertNotNull(color.hsbType);
-        assertEquals(245, color.hsbType.getHue().intValue());
-        assertEquals(100, color.hsbType.getSaturation().intValue());
-        assertEquals(72, color.hsbType.getBrightness().intValue());
+        HSBType hsbType = color.getHSB();
+        assertNotNull(hsbType);
+        assertEquals(158, hsbType.getHue().intValue());
+        assertEquals(100, hsbType.getSaturation().intValue());
+        assertEquals(72, hsbType.getBrightness().intValue());
     }
 
     @Test
     public void testFromHSBTypeKnownGood1() {
-        TradfriColor color = TradfriColor.fromHSBType(HSBType.RED);
-        assertNotNull(color);
-        assertEquals(254, (int) color.rgbR);
-        assertEquals(0, (int) color.rgbG);
-        assertEquals(0, (int) color.rgbB);
-        assertEquals(45914, (int) color.xyX);
-        assertEquals(19615, (int) color.xyY);
+        TradfriColor color = new TradfriColor(HSBType.RED);
+        assertEquals(41947, (int) color.xyX);
+        assertEquals(21625, (int) color.xyY);
         assertEquals(254, (int) color.brightness);
-        assertNotNull(color.hsbType);
-        assertEquals(0, color.hsbType.getHue().intValue());
-        assertEquals(100, color.hsbType.getSaturation().intValue());
-        assertEquals(100, color.hsbType.getBrightness().intValue());
+        HSBType hsbType = color.getHSB();
+        assertNotNull(hsbType);
+        assertEquals(0, hsbType.getHue().intValue());
+        assertEquals(100, hsbType.getSaturation().intValue());
+        assertEquals(100, hsbType.getBrightness().intValue());
     }
 
     @Test
     public void testFromHSBTypeKnownGood2() {
-        TradfriColor color = TradfriColor.fromHSBType(new HSBType("0,100,1"));
-        assertNotNull(color);
-        assertEquals(2, (int) color.rgbR);
-        assertEquals(0, (int) color.rgbG);
-        assertEquals(0, (int) color.rgbB);
-        assertEquals(45914, (int) color.xyX);
-        assertEquals(19615, (int) color.xyY);
+        TradfriColor color = new TradfriColor(new HSBType("0,100,1"));
+        assertEquals(41947, (int) color.xyX);
+        assertEquals(21625, (int) color.xyY);
         assertEquals(2, (int) color.brightness);
-        assertNotNull(color.hsbType);
-        assertEquals(0, color.hsbType.getHue().intValue());
-        assertEquals(100, color.hsbType.getSaturation().intValue());
-        assertEquals(1, color.hsbType.getBrightness().intValue());
+        HSBType hsbType = color.getHSB();
+        assertNotNull(hsbType);
+        assertEquals(0, hsbType.getHue().intValue());
+        assertEquals(100, hsbType.getSaturation().intValue());
+        assertEquals(1, hsbType.getBrightness().intValue());
     }
 
     @Test
     public void testConversionReverse() {
         // convert from HSBType
-        TradfriColor color = TradfriColor.fromHSBType(HSBType.GREEN);
-        assertNotNull(color);
-        assertEquals(0, (int) color.rgbR);
-        assertEquals(254, (int) color.rgbG); // 254 instead of 255 - only approximated calculation
-        assertEquals(0, (int) color.rgbB);
-        assertEquals(11299, (int) color.xyX);
-        assertEquals(48941, (int) color.xyY);
+        TradfriColor color = new TradfriColor(HSBType.GREEN);
+        assertEquals(19660, (int) color.xyX);
+        assertEquals(39321, (int) color.xyY);
         assertEquals(254, (int) color.brightness);
-        assertNotNull(color.hsbType);
-        assertEquals(120, color.hsbType.getHue().intValue());
-        assertEquals(100, color.hsbType.getSaturation().intValue());
-        assertEquals(100, color.hsbType.getBrightness().intValue());
+        HSBType hsbType = color.getHSB();
+        assertNotNull(hsbType);
+        assertEquals(120, hsbType.getHue().intValue());
+        assertEquals(100, hsbType.getSaturation().intValue());
+        assertEquals(100, hsbType.getBrightness().intValue());
         // convert the result again based on the XY values
-        TradfriColor reverse = TradfriColor.fromCie(color.xyX, color.xyY, color.brightness);
-        assertNotNull(reverse);
-        assertEquals(0, (int) reverse.rgbR);
-        assertEquals(254, (int) reverse.rgbG);
-        assertEquals(0, (int) reverse.rgbB);
-        assertEquals(11299, (int) reverse.xyX);
-        assertEquals(48941, (int) reverse.xyY);
+        TradfriColor reverse = new TradfriColor(color.xyX, color.xyY, color.brightness);
+        assertEquals(19660, (int) reverse.xyX);
+        assertEquals(39321, (int) reverse.xyY);
         assertEquals(254, (int) reverse.brightness);
-        assertNotNull(reverse.hsbType);
-        assertEquals(120, reverse.hsbType.getHue().intValue());
-        assertEquals(100, reverse.hsbType.getSaturation().intValue());
-        assertEquals(100, reverse.hsbType.getBrightness().intValue());
+        HSBType hsbTypeReverse = color.getHSB();
+        assertNotNull(hsbTypeReverse);
+        assertEquals(120, hsbTypeReverse.getHue().intValue());
+        assertEquals(100, hsbTypeReverse.getSaturation().intValue());
+        assertEquals(100, hsbTypeReverse.getBrightness().intValue());
     }
 
     @Test
     public void testFromColorTemperatureMinMiddleMax() {
         // coldest color temperature -> preset 1
-        TradfriColor colorMin = TradfriColor.fromColorTemperature(PercentType.ZERO);
+        TradfriColor colorMin = new TradfriColor(PercentType.ZERO);
         assertNotNull(colorMin);
         assertEquals(24933, (int) colorMin.xyX);
         assertEquals(24691, (int) colorMin.xyY);
         // middle color temperature -> preset 2
-        TradfriColor colorMiddle = TradfriColor.fromColorTemperature(new PercentType(50));
+        TradfriColor colorMiddle = new TradfriColor(new PercentType(50));
         assertNotNull(colorMiddle);
         assertEquals(30138, (int) colorMiddle.xyX);
         assertEquals(26909, (int) colorMiddle.xyY);
         // warmest color temperature -> preset 3
-        TradfriColor colorMax = TradfriColor.fromColorTemperature(PercentType.HUNDRED);
+        TradfriColor colorMax = new TradfriColor(PercentType.HUNDRED);
         assertNotNull(colorMax);
         assertEquals(33137, (int) colorMax.xyX);
         assertEquals(27211, (int) colorMax.xyY);
@@ -173,12 +149,12 @@ public class TradfriColorTest {
     @Test
     public void testFromColorTemperatureInbetween() {
         // 30 percent must be between preset 1 and 2
-        TradfriColor color2 = TradfriColor.fromColorTemperature(new PercentType(30));
+        TradfriColor color2 = new TradfriColor(new PercentType(30));
         assertNotNull(color2);
         assertEquals(28056, (int) color2.xyX);
         assertEquals(26022, (int) color2.xyY);
         // 70 percent must be between preset 2 and 3
-        TradfriColor color3 = TradfriColor.fromColorTemperature(new PercentType(70));
+        TradfriColor color3 = new TradfriColor(new PercentType(70));
         assertNotNull(color3);
         assertEquals(31338, (int) color3.xyX);
         assertEquals(27030, (int) color3.xyY);
@@ -187,25 +163,25 @@ public class TradfriColorTest {
     @Test
     public void testCalculateColorTemperature() {
         // preset 1 -> coldest -> 0 percent
-        PercentType preset1 = TradfriColor.calculateColorTemperature(24933, 24691);
+        PercentType preset1 = new TradfriColor(24933, 24691, null).getColorTemperature();
         assertEquals(0, preset1.intValue());
         // preset 2 -> middle -> 50 percent
-        PercentType preset2 = TradfriColor.calculateColorTemperature(30138, 26909);
+        PercentType preset2 = new TradfriColor(30138, 26909, null).getColorTemperature();
         assertEquals(50, preset2.intValue());
         // preset 3 -> warmest -> 100 percent
-        PercentType preset3 = TradfriColor.calculateColorTemperature(33137, 27211);
+        PercentType preset3 = new TradfriColor(33137, 27211, null).getColorTemperature();
         assertEquals(100, preset3.intValue());
         // preset 3 -> warmest -> 100 percent
-        PercentType colder = TradfriColor.calculateColorTemperature(22222, 23333);
+        PercentType colder = new TradfriColor(22222, 23333, null).getColorTemperature();
         assertEquals(0, colder.intValue());
         // preset 3 -> warmest -> 100 percent
-        PercentType temp3 = TradfriColor.calculateColorTemperature(34000, 34000);
+        PercentType temp3 = new TradfriColor(34000, 34000, null).getColorTemperature();
         assertEquals(100, temp3.intValue());
         // mixed case 1
-        PercentType mixed1 = TradfriColor.calculateColorTemperature(0, 1000000);
+        PercentType mixed1 = new TradfriColor(0, 1000000, null).getColorTemperature();
         assertEquals(0, mixed1.intValue());
         // mixed case 1
-        PercentType mixed2 = TradfriColor.calculateColorTemperature(1000000, 0);
+        PercentType mixed2 = new TradfriColor(1000000, 0, null).getColorTemperature();
         assertEquals(100, mixed2.intValue());
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriColor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriColor.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.library.types.PercentType;
  * construction.
  *
  * @author Holger Reichert - Initial contribution
+ * @author Stefan Triller - Use conversions from HSBType
  *
  */
 public class TradfriColor {
@@ -30,12 +31,6 @@ public class TradfriColor {
     // Its own app comes with 3 predefined color temperature settings (0,1,2), which have those values:
     private final static double[] PRESET_X = new double[] { 24933.0, 30138.0, 33137.0 };
     private final static double[] PRESET_Y = new double[] { 24691.0, 26909.0, 27211.0 };
-
-    /**
-     * RGB color values in the range 0 to 255.
-     * May be <code>null</code> if the calculation method does not support this color range.
-     */
-    public Integer rgbR, rgbG, rgbB;
 
     /**
      * CIE XY color values in the tradfri range 0 to 65535.
@@ -50,147 +45,48 @@ public class TradfriColor {
     public Integer brightness;
 
     /**
-     * {@link HSBType} color object.
-     * May be <code>null</code> if the calculation method does not support this color range.
-     */
-    public HSBType hsbType;
-
-    /**
-     * Private constructor based on all fields.
-     *
-     * @param rgbR RGB red value 0 to 255
-     * @param rgbG RGB green value 0 to 255
-     * @param rgbB RGB blue value 0 to 255
-     * @param xyX CIE x value 0 to 65535
-     * @param xyY CIE y value 0 to 65535
-     * @param brightness xy brightness level 0 to 254
-     * @param hsbType {@link HSBType}
-     */
-    private TradfriColor(Integer rgbR, Integer rgbG, Integer rgbB, Integer xyX, Integer xyY, Integer brightness,
-            HSBType hsbType) {
-        super();
-        this.rgbR = rgbR;
-        this.rgbG = rgbG;
-        this.rgbB = rgbB;
-        this.xyX = xyX;
-        this.xyY = xyY;
-        this.brightness = brightness;
-        this.hsbType = hsbType;
-    }
-
-    /**
      * Construct from CIE XY values in the tradfri range.
      *
      * @param xyX x value 0 to 65535
      * @param xyY y value 0 to 65535
      * @param xyBrightness brightness from 0 to 254
-     * @return {@link TradfriColor} object with converted color spaces
      */
-    public static TradfriColor fromCie(int xyX, int xyY, int xyBrightness) {
-
-        // maximum brightness limited to 254
-        int brightness = xyBrightness;
-        if (brightness > 254) {
-            brightness = 254;
+    public TradfriColor(Integer xyX, Integer xyY, Integer brightness) {
+        this.xyX = xyX;
+        this.xyY = xyY;
+        if (brightness != null) {
+            if (brightness > 254) {
+                this.brightness = 254;
+            } else {
+                this.brightness = brightness;
+            }
         }
-
-        double x = unnormalize(xyX);
-        double y = unnormalize(xyY);
-
-        // calculate XYZ using xy and brightness
-        double z = 1.0 - x - y;
-        double Y = (brightness / 254.0);
-        double X = (Y / y) * x;
-        double Z = (Y / y) * z;
-
-        // Wide RGB D65 conversion
-        // math inspiration: http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
-        double red = X * 1.656492 - Y * 0.354851 - Z * 0.255038;
-        double green = -X * 0.707196 + Y * 1.655397 + Z * 0.036152;
-        double blue = X * 0.051713 - Y * 0.121364 + Z * 1.011530;
-
-        // cap all values to 1.0 maximum
-        if (red > blue && red > green && red > 1.0) {
-            green = green / red;
-            blue = blue / red;
-            red = 1.0;
-        } else if (green > blue && green > red && green > 1.0) {
-            red = red / green;
-            blue = blue / green;
-            green = 1.0;
-        } else if (blue > red && blue > green && blue > 1.0) {
-            red = red / blue;
-            green = green / blue;
-            blue = 1.0;
-        }
-
-        // gamma correction - disabled for now - needs tweaking
-        // red = red <= 0.0031308 ? 12.92 * red : (1.0 + 0.055) * Math.pow(red, (1.0 / 2.4)) - 0.055;
-        // green = green <= 0.0031308 ? 12.92 * green : (1.0 + 0.055) * Math.pow(green, (1.0 / 2.4)) - 0.055;
-        // blue = blue <= 0.0031308 ? 12.92 * blue : (1.0 + 0.055) * Math.pow(blue, (1.0 / 2.4)) - 0.055;
-
-        // calculated values can be slightly negative, so cap them to minimum 0.0
-        red = Math.max(0.0, red);
-        green = Math.max(0.0, green);
-        blue = Math.max(0.0, blue);
-
-        int redRounded = (int) Math.round(red * 255.0);
-        int greenRounded = (int) Math.round(green * 255.0);
-        int blueRounded = (int) Math.round(blue * 255.0);
-
-        // construct hsbType from RGB values
-        // this hsbType has corrected values for RGB based on the hue/saturation/brightness values
-        HSBType hsbType = constructHsbTypeFromRgbWithBrightnessPercent(redRounded, greenRounded, blueRounded,
-                brightness);
-        // take RGB values from the HSBType
-        int rgbR = (int) (hsbType.getRed().intValue() * 2.55);
-        int rgbG = (int) (hsbType.getGreen().intValue() * 2.55);
-        int rgbB = (int) (hsbType.getBlue().intValue() * 2.55);
-
-        return new TradfriColor(rgbR, rgbG, rgbB, xyX, xyY, brightness, hsbType);
     }
 
     /**
-     * Construct from {@link HSBType}.
+     * Construct from HSBType
      *
-     * @param hsbType {@link HSBType}
-     * @return {@link TradfriColor} object with converted color spaces
+     * @param hsb HSBType from the framework
      */
-    public static TradfriColor fromHSBType(HSBType hsbType) {
+    public TradfriColor(HSBType hsb) {
+        PercentType[] xyArray = hsb.toXY();
+        this.xyX = normalize(xyArray[0].doubleValue() / 100.0);
+        this.xyY = normalize(xyArray[1].doubleValue() / 100.0);
+        this.brightness = (int) (hsb.getBrightness().floatValue() * 2.54);
+    }
 
-        // hsbType gives 0 to 100, we need 0.0 to 255.0
-        double red = hsbType.getRed().intValue() * 2.55;
-        double green = hsbType.getGreen().intValue() * 2.55;
-        double blue = hsbType.getBlue().intValue() * 2.55;
+    /**
+     * Obtain the TradfriColor (x/y) as HSBType
+     *
+     * @return HSBType representing the x/y Tradfri color
+     */
+    public HSBType getHSB() {
+        float x = unnormalize(xyX);
+        float y = unnormalize(xyY);
 
-        // saved for later use in constructor call
-        int rgbR = (int) red;
-        int rgbG = (int) green;
-        int rgbB = (int) blue;
+        HSBType converted = HSBType.fromXY(x, y);
 
-        // gamma correction - disabled for now - needs tweaking
-        // red = (red > 0.04045) ? Math.pow((red + 0.055) / (1.0 + 0.055), 2.4) : (red / 12.92);
-        // green = (green > 0.04045) ? Math.pow((green + 0.055) / (1.0 + 0.055), 2.4) : (green / 12.92);
-        // blue = (blue > 0.04045) ? Math.pow((blue + 0.055) / (1.0 + 0.055), 2.4) : (blue / 12.92);
-
-        // Wide RGB D65 conversion
-        // math inspiration: http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
-        double X = red * 0.664511 + green * 0.154324 + blue * 0.162028;
-        double Y = red * 0.283881 + green * 0.668433 + blue * 0.047685;
-        double Z = red * 0.000088 + green * 0.072310 + blue * 0.986039;
-
-        // calculate the xy values from XYZ
-        double x = (X / (X + Y + Z));
-        double y = (Y / (X + Y + Z));
-
-        int xyX = normalize(x);
-        int xyY = normalize(y);
-        int brightness = (int) (hsbType.getBrightness().intValue() * 2.54);
-
-        // construct new hsbType with the calculated concrete values
-        HSBType hsbTypeConcreteValues = constructHsbTypeFromRgbWithBrightnessPercent(rgbR, rgbG, rgbB, brightness);
-
-        return new TradfriColor(rgbR, rgbG, rgbB, xyX, xyY, brightness, hsbTypeConcreteValues);
+        return new HSBType(converted.getHue(), converted.getSaturation(), xyBrightnessToPercentType(brightness));
     }
 
     /**
@@ -200,9 +96,8 @@ public class TradfriColor {
      * values set!
      *
      * @param percentType the color temperature in percent
-     * @return {@link TradfriColor} object with x and y values
      */
-    public static TradfriColor fromColorTemperature(PercentType percentType) {
+    public TradfriColor(PercentType percentType) {
         double percent = percentType.doubleValue();
 
         int x, y;
@@ -218,7 +113,8 @@ public class TradfriColor {
             y = (int) Math.round(PRESET_Y[1] + p * (PRESET_Y[2] - PRESET_Y[1]));
         }
 
-        return new TradfriColor(null, null, null, x, y, null, null);
+        this.xyX = x;
+        this.xyY = y;
     }
 
     /**
@@ -227,7 +123,7 @@ public class TradfriColor {
      * @param value double in the range 0.0 to 1.0
      * @return normalized value in the range 0 to 65535
      */
-    private static int normalize(double value) {
+    private int normalize(double value) {
         return (int) (value * 65535 + 0.5);
     }
 
@@ -237,38 +133,16 @@ public class TradfriColor {
      * @param value integer in the range 0 to 65535
      * @return unnormalized value in the range 0.0 to 1.0
      */
-    private static double unnormalize(int value) {
-        return (value / 65535.0);
-    }
-
-    /**
-     * Construct a {@link HSBType} from the given RGB values and the xyBrightness.
-     * RGB is converted to hue, and then the brightness gets applied.
-     *
-     * @param rgbR RGB red value 0 to 255
-     * @param rgbG RGB green value 0 to 255
-     * @param rgbB RGB blue value 0 to 255
-     * @param xyBrightness xy brightness level 0 to 254
-     * @return {@link HSBType}
-     */
-    private static HSBType constructHsbTypeFromRgbWithBrightnessPercent(int rgbR, int rgbG, int rgbB,
-            int xyBrightness) {
-        // construct HSBType from RGB values
-        HSBType hsbFullBright = HSBType.fromRGB(rgbR, rgbG, rgbB);
-        // get hue and saturation from HSBType and construct new HSBType based on these values with the given brightness
-        PercentType brightnessPercent = xyBrightnessToPercentType(xyBrightness);
-        HSBType hsb = new HSBType(hsbFullBright.getHue(), hsbFullBright.getSaturation(), brightnessPercent);
-        return hsb;
+    private float unnormalize(int value) {
+        return (value / 65535.0f);
     }
 
     /**
      * Calculate the color temperature from given x and y values.
      *
-     * @param xyX the CIE x value
-     * @param xyY the CIE y value
      * @return {@link PercentType} with color temperature (0 = coolest, 100 = warmest)
      */
-    public static PercentType calculateColorTemperature(int xyX, int xyY) {
+    public PercentType getColorTemperature() {
         double x = xyX;
         double y = xyY;
         double value = 0.0;

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/model/TradfriLightData.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/model/TradfriLightData.java
@@ -74,7 +74,7 @@ public class TradfriLightData extends TradfriDeviceData {
     }
 
     public TradfriLightData setColorTemperature(PercentType c) {
-        TradfriColor color = TradfriColor.fromColorTemperature(c);
+        TradfriColor color = new TradfriColor(c);
         int x = color.xyX;
         int y = color.xyY;
         logger.debug("New color temperature: {},{} ({} %)", x, y, c.intValue());
@@ -87,16 +87,15 @@ public class TradfriLightData extends TradfriDeviceData {
         JsonElement colorX = attributes.get(COLOR_X);
         JsonElement colorY = attributes.get(COLOR_Y);
         if (colorX != null && colorY != null) {
-            return TradfriColor.calculateColorTemperature(colorX.getAsInt(), colorY.getAsInt());
+            TradfriColor color = new TradfriColor(colorX.getAsInt(), colorY.getAsInt(), null);
+            return color.getColorTemperature();
         } else {
             return null;
         }
     }
 
     public TradfriLightData setColor(HSBType hsb) {
-        // construct new HSBType with full brightness and extract XY color values from it
-        HSBType hsbFullBright = new HSBType(hsb.getHue(), hsb.getSaturation(), PercentType.HUNDRED);
-        TradfriColor color = TradfriColor.fromHSBType(hsbFullBright);
+        TradfriColor color = new TradfriColor(hsb);
         attributes.add(COLOR_X, new JsonPrimitive(color.xyX));
         attributes.add(COLOR_Y, new JsonPrimitive(color.xyY));
         return this;
@@ -111,9 +110,8 @@ public class TradfriLightData extends TradfriDeviceData {
             int x = colorX.getAsInt();
             int y = colorY.getAsInt();
             int brightness = dimmer.getAsInt();
-            // extract HSBType from converted xy/brightness
-            TradfriColor color = TradfriColor.fromCie(x, y, brightness);
-            return color.hsbType;
+            TradfriColor color = new TradfriColor(x, y, brightness);
+            return color.getHSB();
         }
         return null;
     }


### PR DESCRIPTION
By using the conversion from HSBType we also apply Gamma correction so the values slightly differ to the version without correction. Nevertheless the colors look as expected on a real Tradfri bulb.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>